### PR TITLE
Use default stack size of none was computed

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -1863,7 +1863,7 @@ uint16_t
 ubpf_stack_usage_for_local_func(const struct ubpf_vm* vm, uint16_t pc)
 {
     uint16_t stack_usage = UBPF_EBPF_STACK_SIZE;
-    if (vm->local_func_stack_usage[pc].stack_usage_calculated) {
+    if (vm->local_func_stack_usage[pc].stack_usage) {
         stack_usage = vm->local_func_stack_usage[pc].stack_usage;
     }
     return stack_usage;


### PR DESCRIPTION
This pull request includes a small change to the `vm/ubpf_vm.c` file. The change modifies the condition in the `ubpf_stack_usage_for_local_func` function to check for `stack_usage` instead of `stack_usage_calculated`.

* [`vm/ubpf_vm.c`](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL1866-R1866): Modified the condition in the `ubpf_stack_usage_for_local_func` function to check `stack_usage` instead of `stack_usage_calculated`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in stack usage calculations for local functions, enhancing overall performance.
  
- **Refactor**
	- Simplified logic for determining stack usage by removing redundant conditions, leading to cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->