### PR TITLE
Verifier integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/bpf_conformance"]
 	path = external/bpf_conformance
 	url = https://github.com/Alan-Jowett/bpf_conformance.git
+[submodule "external/ebpf-verifier"]
+	path = external/ebpf-verifier
+	url = https://github.com/vbpf/ebpf-verifier.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,4 +43,5 @@ endif()
 
 if (UBPF_ENABLE_LIBFUZZER)
   add_subdirectory("libfuzzer")
+  add_subdirectory("external/ebpf-verifier")
 endif()

--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -13,17 +13,24 @@ add_executable(
     libfuzz_harness.cc
 )
 
+message(STATUS "GSL_INCLUDE_DIRS: ${CMAKE_BINARY_DIR}/gsl-src/include")
+
 target_include_directories("ubpf_fuzzer" PRIVATE
     "${CMAKE_SOURCE_DIR}/vm"
     "${CMAKE_BINARY_DIR}/vm"
+    "${CMAKE_BINARY_DIR}/_deps/gsl-src/include"
     "${CMAKE_SOURCE_DIR}/vm/inc"
     "${CMAKE_BINARY_DIR}/vm/inc"
     "${CMAKE_SOURCE_DIR}/ubpf_plugin"
+    "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src"
+    "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src/crab"
+    "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src/crab_utils"
 )
 
 target_link_libraries(
     ubpf_fuzzer
     ubpf
     ubpf_settings
+    ebpfverifier
 )
 

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -577,7 +577,8 @@ extern "C"
         int program_counter,
         const uint64_t registers[16],
         const uint8_t* stack_start,
-        size_t stack_length);
+        size_t stack_length,
+        uint64_t register_mask);
 
     /**
      * @brief Add option to invoke a debug function before each instruction.

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -679,7 +679,7 @@ ubpf_exec_ex(
 
         // Invoke the debug function to allow the user to inspect the state of the VM if it is enabled.
         if (vm->debug_function) {
-            vm->debug_function(vm->debug_function_context, cur_pc, reg, stack_start, stack_length);
+            vm->debug_function(vm->debug_function_context, cur_pc, reg, stack_start, stack_length, shadow_registers);
         }
 
         if (!ubpf_validate_shadow_register(vm, &shadow_registers, inst)) {


### PR DESCRIPTION
This pull request adds support for the `ebpf-verifier` submodule and integrates it into the existing `libfuzzer` setup. The most important changes include adding the new submodule, modifying the build system to include the verifier, and updating the `libfuzzer` harness to use the verifier for enhanced functionality and debugging.

### Submodule Addition:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R7-R9): Added `ebpf-verifier` submodule.

### Build System Updates:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR46): Included `ebpf-verifier` in the build process when `UBPF_ENABLE_LIBFUZZER` is enabled.
* [`libfuzzer/CMakeLists.txt`](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aR16-R34): Added include directories and linked `ebpf-verifier` library.

### Code Enhancements:
* `libfuzzer/libfuzz_harness.cc`: 
  * Added includes for `ebpf-verifier` headers.
  * Implemented functions for context and stack handling, and integrated the verifier into the execution flow. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R114-R152) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R206-R285) [[3]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R300-R310) [[4]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R333-R334) [[5]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L157-R351) [[6]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R437-R441)

### Debugging and Verification:
* [`vm/inc/ubpf.h`](diffhunk://#diff-47050594ea372d3c6a44bce95ada2feb7306a466565cca08aa9458d69cf92b3aL580-R581): Updated the debug function signature to include a register mask.
* [`vm/ubpf_vm.c`](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL682-R682): Modified `ubpf_exec_ex` to pass the register mask to the debug function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new submodule, `ebpf-verifier`, enhancing the uBPF virtual machine's capabilities.
	- Added a new fuzzer executable to improve testing and verification of uBPF programs.
	- Enhanced debugging features for better program analysis and error tracking.

- **Bug Fixes**
	- Improved robustness and functionality of the uBPF harness and virtual machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->