### PR TITLE
Fix labelling for local calls

### DIFF
--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -30,20 +30,6 @@ set(UBPF_FUZZER_LIBS
 
 set(CMAKE_REQUIRED_INCLUDES ${UBPF_FUZZER_INCLUDES})
 
-include(CheckCXXSourceCompiles)
-
-# Check if the ebpf verifier supports checking constraints at labels.
-set(CHECK_CONFIG_STORE_PRE_INVARIANTS "
-#include <config.hpp>
-int main() {
-    ebpf_verifier_options_t options;
-    options.store_pre_invariants = true;
-    return 0;
-}
-")
-
-check_cxx_source_compiles("${CHECK_CONFIG_STORE_PRE_INVARIANTS}" HAVE_EBPF_VERIFIER_CHECK_CONSTRAINTS_AT_LABEL)
-
 set(CMAKE_CXX_STANDARD 20)
 
 configure_file(


### PR DESCRIPTION
This pull request includes several changes to the `libfuzzer` component, focusing on enhancing the context management and removing conditional compilation checks. The most significant changes include adding new fields to the `ubpf_context_t` structure, updating functions to handle these new fields, and removing conditional compilation checks.

### Context management improvements:
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R92-R93): Added `program_start` and `program_end` fields to the `ubpf_context_t` structure. Updated the `ubpf_context_from` function to initialize these new fields. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R92-R93) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L612-R630) [[3]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R639-R640)
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L690-R710): Updated `call_ubpf_interpreter` and `call_ubpf_jit` functions to pass `program_code` to `ubpf_context_from`. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L690-R710) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L733-R753)

### Conditional compilation removal:
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L362-L364): Removed `#if defined(HAVE_EBPF_VERIFIER_CHECK_CONSTRAINTS_AT_LABEL)` checks and related error handling, making the code simpler and more streamlined. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L362-L364) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L594-L600)

### Additional changes:
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R495-R496): Introduced a `g_pc_stack` vector to track program counters and updated the `ubpf_debug_function` to utilize this stack for local call and exit instructions. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R495-R496) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R531-R561)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced debugging capabilities with the addition of `program_start` and `program_end` fields for better tracking of program execution.
	- Improved error handling and detailed output for the program verification process.

- **Bug Fixes**
	- Refined error handling in the verification process, ensuring robustness.

- **Documentation**
	- Updated functions to reflect new context fields for improved clarity on usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->